### PR TITLE
DOC: Fix episode links in `README` content table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ An introduction to the Brain Imaging Data Structure (BIDS) and working with BIDS
 
 | \#   | Episode | Time | Questions                                                   | 
 | --- | ------- | :--: | ----------------------------------------------------------- |
-| 1   | [Introduction to BIDS-EEG](https://carpentries-incubator.github.io/SDC-BIDS-EEG-EEGLAB/01-intro_BIDS_EEG/index.html)        | 30   | Why are data standards important? <br> What information needs to be standardized for EEG?                          | 
-| 2   | [Matlab: need to knows](https://carpentries-incubator.github.io/SDC-BIDS-EEG-EEGLAB/02-data_property/index.html)        | 30   | What does EEGLAB need to know about the folder structures? <br> How to set up the paths in Matlab for EEGLAB | 
-| 3   | [Initializing Data into the BIDS standard](https://carpentries-incubator.github.io/SDC-BIDS-EEG-EEGLAB/03-BIDS_init_EEG_EEGLAB/index.html)        | 30   | How do I get my data into the BIDS standard? <br> What does a BIDS folder structure look like?               | 
+| 1   | [Introduction to BIDS-EEG](https://carpentries-incubator.github.io/SDC-BIDS-EEG-EEGLAB/01-intro_BIDS_EEG.html)        | 30   | Why are data standards important? <br> What information needs to be standardized for EEG?                          |
+| 2   | [Matlab: need to knows](https://carpentries-incubator.github.io/SDC-BIDS-EEG-EEGLAB/02-data_property.html)        | 30   | What does EEGLAB need to know about the folder structures? <br> How to set up the paths in Matlab for EEGLAB |
+| 3   | [Initializing Data into the BIDS standard](https://carpentries-incubator.github.io/SDC-BIDS-EEG-EEGLAB/03-BIDS_init_EEG_EEGLAB.html)        | 30   | How do I get my data into the BIDS standard? <br> What does a BIDS folder structure look like?               |
 
 ## Contributing
 


### PR DESCRIPTION
Fix episode links in `README` file content table: links have changed after the transition to the Carpentries Workbench infrastructure.